### PR TITLE
Freeze the config object

### DIFF
--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -6,6 +6,6 @@ const config = {
     PORT: process.env.PORT || 3000,
     MONGO_URL: process.env.MONGO_URL as string,
     MODE: process.env.NODE_ENV as "development" | "production"
-}
+} as const;
 
 export default config;


### PR DESCRIPTION
This PR introduces a change that ensures that the config object will never change in anywhere in the code by human accident or anything else, by using `const as const` syntax, which is a helpful thing in TypeScript. 

## Explanation
the `const` keyword behaves differently from what you think. Constant variables are designed to protect any change from a pointer to another one. In simpler word, it means that if you have a constant variable like this (or any other kind of variable in general):
```ts
const greeting = "Hello World!";
```

The key `greeting` points to a specific place in the memory where `"Hello World!"` is stored. In constant variables, you cannot make `greeting` to point to another place in the memory, because of its behavior. 

With that being said, it's the behavior that is only normal when you are working with primitive types. For reference types, it's a little bit different. 

Let's say you have the following:
```ts
const user = { fullName: "John Doe", age: 12 }; 
```

You cannot re-assign the `user` variable to be anything else
```ts
user = "Huh?"; // This won't work
```

However, it's possible to change the properties of the object, since it's a reference type.
```ts
user.age = 14; // That's totally fine:) 
```

## Why this change is important and necessary?
The `config` contains crucial content of configuration that could be changed by accident in the code or by nasty users (to be honest, I don't know how but I know it's potential). We must ensure that every single property of the config is not going to be changed, so we can use them with ease of mind. 

That's a very simple but very important change. I hope that makes sense. 